### PR TITLE
Feat/generalized actions

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -302,6 +302,17 @@ path = 'contracts/dao/traits/aibtcdev-dao-v1.clar'
 clarity_version = 2
 epoch = 3.0
 
+# actions
+[contracts.set-account-holder]
+path = 'contracts/dao/extensions/actions/set-account-holder.clar'
+clarity_version = 2
+epoch = 3.0
+
+[contracts.send-message]
+path = 'contracts/dao/extensions/actions/send-message.clar'
+clarity_version = 2
+epoch = 3.0
+
 # testing utilities
 
 [contracts.test-treasury]

--- a/contracts/dao/extensions/actions/send-message.clar
+++ b/contracts/dao/extensions/actions/send-message.clar
@@ -1,0 +1,20 @@
+(impl-trait .aibtcdev-dao-traits-v1.extension)
+(impl-trait .aibtcdev-dao-traits-v1.action)
+
+(define-constant ERR_UNAUTHORIZED (err u10001))
+(define-constant ERR_INVALID_PARAMS (err u10002))
+
+(define-public (callback (sender principal) (memo (buff 34))) (ok true))
+
+(define-public (run (parameters (buff 2048)))
+  (begin
+    (try! (is-dao-or-extension))
+    (contract-call? .aibtc-onchain-messaging send (unwrap! (from-consensus-buff? (string-ascii 2043) parameters) ERR_INVALID_PARAMS) true)
+  )
+)
+
+(define-private (is-dao-or-extension)
+  (ok (asserts! (or (is-eq tx-sender .aibtcdev-base-dao)
+    (contract-call? .aibtcdev-base-dao is-extension contract-caller)) ERR_UNAUTHORIZED
+  ))
+)

--- a/contracts/dao/extensions/actions/set-account-holder.clar
+++ b/contracts/dao/extensions/actions/set-account-holder.clar
@@ -1,0 +1,20 @@
+(impl-trait .aibtcdev-dao-traits-v1.extension)
+(impl-trait .aibtcdev-dao-traits-v1.action)
+
+(define-constant ERR_UNAUTHORIZED (err u10001))
+(define-constant ERR_INVALID_PARAMS (err u10002))
+
+(define-public (callback (sender principal) (memo (buff 34))) (ok true))
+
+(define-public (run (parameters (buff 2048)))
+  (begin
+    (try! (is-dao-or-extension))
+    (contract-call? .aibtc-bank-account set-account-holder (unwrap! (from-consensus-buff? principal parameters) ERR_INVALID_PARAMS))
+  )
+)
+
+(define-private (is-dao-or-extension)
+  (ok (asserts! (or (is-eq tx-sender .aibtcdev-base-dao)
+    (contract-call? .aibtcdev-base-dao is-extension contract-caller)) ERR_UNAUTHORIZED
+  ))
+)

--- a/contracts/dao/extensions/aibtc-action-proposals.clar
+++ b/contracts/dao/extensions/aibtc-action-proposals.clar
@@ -282,9 +282,10 @@
       })
     )
     ;; execute the action only if it passed
-    ;; (and votePassed (try! (execute-action proposalRecord)))
-    ;; return the result
-    (ok (and votePassed (try! (contract-call? action run (get parameters proposalRecord)))))
+    (ok (if votePassed
+      (match (contract-call? action run (get parameters proposalRecord)) ok_ true err_ (begin (print {err:err_}) false))
+      false
+    ))
   )
 )
 

--- a/contracts/dao/extensions/aibtc-action-proposals.clar
+++ b/contracts/dao/extensions/aibtc-action-proposals.clar
@@ -264,6 +264,8 @@
     (asserts! (>= burn-block-height (get endBlock proposalRecord)) ERR_PROPOSAL_STILL_ACTIVE)
     ;; proposal not already concluded
     (asserts! (not (get concluded proposalRecord)) ERR_PROPOSAL_ALREADY_CONCLUDED)
+    ;; action must be the same as the one in proposal
+    (asserts! (is-eq (get action proposalRecord) (contract-of action)) ERR_INVALID_ACTION)
     ;; print conclusion event
     (print {
       notification: "conclude-proposal",

--- a/contracts/dao/extensions/aibtc-action-proposals.clar
+++ b/contracts/dao/extensions/aibtc-action-proposals.clar
@@ -60,7 +60,7 @@
 
 ;; data vars
 ;;
-(define-data-var protocolTreasury principal .aibtc-treasury) ;; the treasury contract for protocol funds
+(define-data-var protocolTreasury principal SELF) ;; the treasury contract for protocol funds
 (define-data-var votingToken principal SELF) ;; the FT contract used for voting
 
 ;; data maps
@@ -128,8 +128,6 @@
       (treasuryContract (contract-of treasury))
     )
     (try! (is-dao-or-extension))
-    ;; treasury must be a contract
-    (asserts! (not (is-standard treasuryContract)) ERR_TREASURY_MUST_BE_CONTRACT)
     ;; treasury must not be already set
     (asserts! (is-eq (var-get protocolTreasury) SELF) ERR_TREASURY_NOT_INITIALIZED)
     ;; treasury cannot be the voting contract
@@ -145,22 +143,17 @@
 )
 
 (define-public (set-voting-token (token <ft-trait>))
-  (let
-    (
-      (tokenContract (contract-of token))
-    )
+  (begin
     (try! (is-dao-or-extension))
-    ;; token must be a contract
-    (asserts! (not (is-standard tokenContract)) ERR_TOKEN_MUST_BE_CONTRACT)
     ;; token must not be already set
     (asserts! (is-eq (var-get votingToken) SELF) ERR_TOKEN_NOT_INITIALIZED)
     (print {
       notification: "set-voting-token",
       payload: {
-        token: tokenContract
+        token: token
       }
     })
-    (ok (var-set votingToken tokenContract))
+    (ok (var-set votingToken (contract-of token)))
   )
 )
 

--- a/contracts/dao/proposals/aibtc-base-bootstrap-initialization.clar
+++ b/contracts/dao/proposals/aibtc-base-bootstrap-initialization.clar
@@ -13,6 +13,8 @@
         {extension: .aibtc-onchain-messaging, enabled: true}
         {extension: .aibtc-payments-invoices, enabled: true}
         {extension: .aibtc-treasury, enabled: true}
+        {extension: .set-account-holder, enabled: true}
+        {extension: .send-message, enabled: true}
       )
     ))
 

--- a/contracts/dao/proposals/aibtc-base-bootstrap-initialization.clar
+++ b/contracts/dao/proposals/aibtc-base-bootstrap-initialization.clar
@@ -15,6 +15,9 @@
         {extension: .aibtc-treasury, enabled: true}
       )
     ))
+
+    (try! (contract-call? .aibtc-action-proposals set-protocol-treasury .aibtc-treasury))
+    (try! (contract-call? .aibtc-action-proposals set-voting-token .aibtc-token))
     ;; print manifest
     (print DAO_MANIFEST)
     (ok true)

--- a/contracts/dao/traits/aibtcdev-dao-traits-v1.clar
+++ b/contracts/dao/traits/aibtcdev-dao-traits-v1.clar
@@ -164,3 +164,9 @@
   ;; @returns (response bool uint)
   (conclude-proposal (<proposal> <treasury> <ft-trait>) (response bool uint))
 ))
+
+(define-trait action (
+  ;; @param parameters encoded action parameters
+  ;; @returns (response bool uint)
+  (run ((buff 2048)) (response bool uint))
+))


### PR DESCRIPTION
This PR generalize actions.

Each action should conform to `extension` and `action` trait and should be registered in DAO as extension.

> [!caution]
> **SECURITY**
> It is more likely than not, that `action` passed as `propose-action` argument should be validated. The basic check if it is registered and enabled extension should do the job, but at this moment I don't know if that's enough.