### PR TITLE
Implement snapshot voting

### DIFF
--- a/contracts/dao/extensions/aibtc-action-proposals.clar
+++ b/contracts/dao/extensions/aibtc-action-proposals.clar
@@ -234,6 +234,8 @@
     )
     ;; required variables must be set
     (asserts! (is-initialized) ERR_NOT_INITIALIZED)
+    ;; verify extension still active in dao
+    (try! (as-contract (is-dao-or-extension)))
     ;; verify treasury matches protocol treasury
     (asserts! (is-eq treasuryContract (var-get protocolTreasury)) ERR_TREASURY_MISMATCH)
     ;; proposal past end block height


### PR DESCRIPTION
Change applies to both core and action proposals. One caveat is we cannot use the read-only function from the trait so we have to hardcode the contract, but this pattern may be preferable since we are using templates on the backend anyway.

To put it another way, instead of initializing these contracts with the token contract, we can reference it directly since it gets deployed first. This should simplify the scripts / info needed to call it as well.