### PR TITLE
Simplify token definition

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -282,18 +282,8 @@ path = 'contracts/dao/proposals/aibtc-action-proposals-set-protocol-treasury.cla
 clarity_version = 2
 epoch = 3.0
 
-[contracts.aibtc-action-proposals-set-voting-token]
-path = 'contracts/dao/proposals/aibtc-action-proposals-set-voting-token.clar'
-clarity_version = 2
-epoch = 3.0
-
 [contracts.aibtc-core-proposals-set-protocol-treasury]
 path = 'contracts/dao/proposals/aibtc-core-proposals-set-protocol-treasury.clar'
-clarity_version = 2
-epoch = 3.0
-
-[contracts.aibtc-core-proposals-set-voting-token]
-path = 'contracts/dao/proposals/aibtc-core-proposals-set-voting-token.clar'
 clarity_version = 2
 epoch = 3.0
 

--- a/contracts/dao/extensions/aibtc-payments-invoices.clar
+++ b/contracts/dao/extensions/aibtc-payments-invoices.clar
@@ -42,7 +42,7 @@
 (define-data-var totalRevenue uint u0)
 
 ;; dao can update payment address
-(define-data-var paymentAddress principal .aibtc-bank-account)
+(define-data-var paymentAddress principal .aibtc-treasury)
 
 ;; data maps
 ;;

--- a/contracts/dao/proposals/aibtc-action-proposals-set-voting-token.clar
+++ b/contracts/dao/proposals/aibtc-action-proposals-set-voting-token.clar
@@ -1,5 +1,0 @@
-(impl-trait .aibtcdev-dao-traits-v1.proposal)
-
-(define-public (execute (sender principal))
-  (contract-call? .aibtc-action-proposals set-voting-token .aibtc-token)
-)

--- a/contracts/dao/proposals/aibtc-base-bootstrap-initialization.clar
+++ b/contracts/dao/proposals/aibtc-base-bootstrap-initialization.clar
@@ -4,7 +4,7 @@
 
 (define-public (execute (sender principal))
   (begin  
-    ;; set initial extensions
+    ;; set initial extensions list
     (try! (contract-call? .aibtcdev-base-dao set-extensions
       (list
         {extension: .aibtc-action-proposals, enabled: true}
@@ -12,14 +12,18 @@
         {extension: .aibtc-core-proposals, enabled: true}
         {extension: .aibtc-onchain-messaging, enabled: true}
         {extension: .aibtc-payments-invoices, enabled: true}
+        {extension: .aibtc-token-owner, enabled: true}
         {extension: .aibtc-treasury, enabled: true}
-        {extension: .set-account-holder, enabled: true}
-        {extension: .send-message, enabled: true}
       )
     ))
-
+    ;; initialize action proposals
     (try! (contract-call? .aibtc-action-proposals set-protocol-treasury .aibtc-treasury))
-    (try! (contract-call? .aibtc-action-proposals set-voting-token .aibtc-token))
+    ;; initialize core proposals
+    (try! (contract-call? .aibtc-core-proposals set-protocol-treasury .aibtc-treasury))
+    ;; send DAO manifest as onchain message
+    (try! (contract-call? .aibtc-onchain-messaging send DAO_MANIFEST true))
+    ;; allow assets in treasury
+    (try! (contract-call? .aibtc-treasury allow-asset .aibtc-token true))
     ;; print manifest
     (print DAO_MANIFEST)
     (ok true)

--- a/contracts/dao/proposals/aibtc-core-proposals-set-voting-token.clar
+++ b/contracts/dao/proposals/aibtc-core-proposals-set-voting-token.clar
@@ -1,5 +1,0 @@
-(impl-trait .aibtcdev-dao-traits-v1.proposal)
-
-(define-public (execute (sender principal))
-  (contract-call? .aibtc-action-proposals set-voting-token .aibtc-token)
-)

--- a/contracts/dao/traits/aibtcdev-dao-traits-v1.clar
+++ b/contracts/dao/traits/aibtcdev-dao-traits-v1.clar
@@ -30,29 +30,22 @@
   ;; @param treasury the treasury contract principal
   ;; @returns (response bool uint)
   (set-protocol-treasury (<treasury>) (response bool uint))
-  ;; set the voting token contract
-  ;; @param token the token contract principal
-  ;; @returns (response bool uint)
-  (set-voting-token (<ft-trait>) (response bool uint))
   ;; propose a new action
   ;; @param action the action contract
   ;; @param parameters encoded action parameters
-  ;; @param token the voting token contract
   ;; @returns (response bool uint)
-  (propose-action (<action> (buff 2048) <ft-trait>) (response bool uint))
+  (propose-action (<action> (buff 2048)) (response bool uint))
   ;; vote on an existing proposal
   ;; @param proposal the proposal id
-  ;; @param token the voting token contract
   ;; @param vote true for yes, false for no
   ;; @returns (response bool uint)
-  (vote-on-proposal (uint <ft-trait> bool) (response bool uint))
+  (vote-on-proposal (uint bool) (response bool uint))
   ;; conclude a proposal after voting period
   ;; @param proposal the proposal id
   ;; @param action the action contract
   ;; @param treasury the treasury contract
-  ;; @param token the voting token contract
   ;; @returns (response bool uint)
-  (conclude-proposal (uint <action> <treasury> <ft-trait>) (response bool uint))
+  (conclude-proposal (uint <action> <treasury>) (response bool uint))
 ))
 
 (define-trait bank-account (


### PR DESCRIPTION
Since it's one dao per token and we're using templates, we can specify the token ahead of time rather than initializing it. This reduces the need to check and provide the token with some calls, and will require syncing up the related templates next.

Breaking change: this updates trait signatures, will need to redeploy on testnet/mainnet